### PR TITLE
Rely on BSP for heap preparation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "teensy4-bsp"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461610509d62db01ed1aa660c78d0bb04001d279769113ebea3046de57039efd"
+checksum = "2189bca2b9477ea3305f39bdcd2718877e10810c780a5912c75f14aec8f14d46"
 dependencies = [
  "cortex-m 0.6.7",
  "cortex-m-rt",
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "teensy4-panic"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e307eec1203a9b340f41d77d72357fa6e327b1ab9b12d593725a5ce17236b2da"
+checksum = "486e5bedc1be2a115dd3bd0deb96dcf558141b2ea0b11445093cbc2ab2972f50"
 
 [[package]]
 name = "teensy4-pins"

--- a/src/bin/day_01/main.rs
+++ b/src/bin/day_01/main.rs
@@ -16,7 +16,6 @@ use cortex_m_rt::entry;
 use core::fmt::Write;
 
 use aoc21::utils::Hardware;
-use aoc21::runtime::Memory;
 use aoc21::usbwriteln;
 
 use container::Sonar;
@@ -28,7 +27,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol);
 }
 
 struct Solution {

--- a/src/bin/day_02/main.rs
+++ b/src/bin/day_02/main.rs
@@ -8,7 +8,6 @@ use cortex_m_rt::entry;
 use core::fmt::Write;
 
 use aoc21::utils::Hardware;
-use aoc21::runtime::Memory;
 use aoc21::usbwriteln;
 
 use container::{Course, Command};
@@ -21,7 +20,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {

--- a/src/bin/day_03/main.rs
+++ b/src/bin/day_03/main.rs
@@ -9,7 +9,6 @@ use cortex_m_rt::entry;
 use core::fmt::Write;
 
 use aoc21::utils::Hardware;
-use aoc21::runtime::Memory;
 use aoc21::usbwriteln;
 
 use container::*;
@@ -23,7 +22,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {

--- a/src/bin/day_04/main.rs
+++ b/src/bin/day_04/main.rs
@@ -10,7 +10,6 @@ use core::fmt::Write;
 use alloc::vec::Vec;
 
 use aoc21::utils::Hardware;
-use aoc21::runtime::Memory;
 use aoc21::usbwriteln;
 
 use container::*;
@@ -23,7 +22,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {

--- a/src/bin/day_05/main.rs
+++ b/src/bin/day_05/main.rs
@@ -12,7 +12,6 @@ use alloc::vec::Vec;
 use core::fmt::Write;
 
 use aoc21::{utils::Hardware, usbwriteln};
-use aoc21::runtime::Memory;
 use aoc21::runtime::ALLOCATOR;
 
 use container::*;
@@ -25,7 +24,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution { };
-    aoc21::runtime::run(&mut sol, Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {

--- a/src/bin/day_06/main.rs
+++ b/src/bin/day_06/main.rs
@@ -8,7 +8,6 @@ use cortex_m_rt::entry;
 use core::fmt::Write;
 
 use aoc21::{utils::Hardware, usbwriteln};
-use aoc21::runtime::Memory;
 
 use container::*;
 
@@ -20,7 +19,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {

--- a/src/bin/day_07/main.rs
+++ b/src/bin/day_07/main.rs
@@ -8,7 +8,6 @@ use cortex_m_rt::entry;
 use core::fmt::Write;
 
 use aoc21::{utils::Hardware, usbwriteln};
-use aoc21::runtime::Memory;
 
 use container::*;
 
@@ -20,7 +19,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {

--- a/src/bin/day_08/main.rs
+++ b/src/bin/day_08/main.rs
@@ -10,7 +10,6 @@ use cortex_m_rt::entry;
 use core::{fmt::Write, convert::TryFrom};
 
 use aoc21::{utils::Hardware, usbwriteln};
-use aoc21::runtime::Memory;
 
 use container::*;
 
@@ -22,7 +21,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {

--- a/src/bin/day_09/main.rs
+++ b/src/bin/day_09/main.rs
@@ -12,7 +12,6 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use aoc21::{utils::Hardware, usbwriteln};
-use aoc21::runtime::Memory;
 
 use container::*;
 
@@ -24,7 +23,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {

--- a/src/bin/day_10/main.rs
+++ b/src/bin/day_10/main.rs
@@ -11,7 +11,6 @@ use alloc::vec::Vec;
 use alloc::string::String;
 
 use aoc21::{utils::Hardware, usbwriteln};
-use aoc21::runtime::Memory;
 
 use container::*;
 
@@ -23,7 +22,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {

--- a/src/bin/day_11/main.rs
+++ b/src/bin/day_11/main.rs
@@ -8,7 +8,6 @@ use cortex_m_rt::entry;
 use core::fmt::Write;
 
 use aoc21::{utils::Hardware, usbwriteln};
-use aoc21::runtime::Memory;
 
 use container::*;
 
@@ -20,7 +19,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {

--- a/src/bin/day_12/main.rs
+++ b/src/bin/day_12/main.rs
@@ -9,7 +9,6 @@ use cortex_m_rt::entry;
 use core::fmt::Write;
 
 use aoc21::{utils::Hardware, usbwriteln};
-use aoc21::runtime::Memory;
 
 use container::*;
 
@@ -21,7 +20,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {

--- a/src/bin/day_13/main.rs
+++ b/src/bin/day_13/main.rs
@@ -8,7 +8,6 @@ use cortex_m_rt::entry;
 use core::fmt::Write;
 
 use aoc21::{utils::Hardware, usbwriteln};
-use aoc21::runtime::Memory;
 
 use container::*;
 
@@ -20,7 +19,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {

--- a/src/bin/day_14/main.rs
+++ b/src/bin/day_14/main.rs
@@ -10,7 +10,6 @@ use core::fmt::Write;
 use alloc::collections::BTreeMap;
 
 use aoc21::{utils::Hardware, usbwriteln};
-use aoc21::runtime::Memory;
 
 use container::*;
 
@@ -22,7 +21,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {

--- a/src/bin/day_15/main.rs
+++ b/src/bin/day_15/main.rs
@@ -24,7 +24,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, aoc21::runtime::Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol);
 }
 
 struct Solution {

--- a/src/bin/day_16/main.rs
+++ b/src/bin/day_16/main.rs
@@ -8,7 +8,6 @@ use cortex_m_rt::entry;
 use core::fmt::Write;
 
 use aoc21::utils::Hardware;
-use aoc21::runtime::Memory;
 use aoc21::usbwriteln;
 
 use container::*;
@@ -21,7 +20,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(400_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {

--- a/src/bin/day_17/main.rs
+++ b/src/bin/day_17/main.rs
@@ -9,7 +9,6 @@ use cortex_m_rt::entry;
 use core::fmt::Write;
 
 use aoc21::{utils::Hardware, usbwriteln};
-use aoc21::runtime::Memory;
 
 use container::*;
 use track::{Track, Vector};
@@ -22,7 +21,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(300_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {}

--- a/src/bin/day_18/main.rs
+++ b/src/bin/day_18/main.rs
@@ -11,7 +11,6 @@ use cortex_m_rt::entry;
 use core::fmt::Write;
 
 use aoc21::utils::Hardware;
-use aoc21::runtime::Memory;
 
 use container::*;
 
@@ -25,7 +24,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(300_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {}

--- a/src/bin/template/main.rs
+++ b/src/bin/template/main.rs
@@ -7,8 +7,6 @@ use teensy4_panic as _;
 use cortex_m_rt::entry;
 
 use aoc21::utils::Hardware;
-use aoc21::runtime::Memory;
-
 use container::*;
 
 
@@ -19,7 +17,7 @@ fn wrapper() -> ! {
 
 fn main() -> ! {
     let mut sol = Solution {};
-    aoc21::runtime::run(&mut sol, Memory::RAM1(300_000));
+    aoc21::runtime::run(&mut sol)
 }
 
 struct Solution {}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -24,43 +24,9 @@ pub use super::utils::container::Hardware;
 #[global_allocator]
 pub static ALLOCATOR: CortexMHeap = CortexMHeap::empty();
 
-/** Available memory areas 
- * for heap initialization.
- *
- * RAM1 is regarded faster, but shares
- * it's space with other things.
- *
- * RAM2 is slower, but isn't used by the compiler.
- *
- * For the teensy 4.1 the RAM locations can 
- * also be found in the [linker
- * script](https://github.com/mciantyre/teensy4-rs/blob/master/t4link.x)
- *
- * For further details read 
- * [the Teensy4.1 page](https://www.pjrc.com/store/teensy41.html#memory)
- *
- * RAM1 is DTCM and RAM2 is OCRAM2 in the I.MX RT1060 reference manual
- * 
- */
-pub enum Memory {
-    RAM1(usize),
-    RAM2
-}
-
-pub fn run<O, T>(solution: &mut T, heap_memory: Memory) -> ! where O:ParsedData, T : Solution<O> {
+pub fn run<O, T>(solution: &mut T) -> ! where O:ParsedData, T : Solution<O> {
     // init allocator
-    let (start, mut size) = match heap_memory {
-        Memory::RAM1(size) => (cortex_m_rt::heap_start() as usize, size),
-        Memory::RAM2 => (0x2020_0000 + 0x5000, 0)
-    };
-
-    if size == 0 {
-        /* universal size calculation independent 
-         * wether we are on OCRAM2 (RAM2) or DTCM (RAM1)
-         * as they always end on …7_FFFF
-         * - see I.MX RT1060 ref man - page 36 */
-        size = 0x7_FFFF - (start % 0x8_0000) - 10_000;
-    }
+    let (start, size) =  (bsp::heap_start() as usize, bsp::heap_len());
 
     unsafe { ALLOCATOR.init(start, size) }
 


### PR DESCRIPTION
Release 0.2.1 of the BSP moves the heap into OCRAM2. Your question about RAM made me notice that the heap wasn't allocated correctly. Thanks for that.

The PR removes the `Memory` variant. As of 0.2.1, both `RAM1` and `RAM2` would end up allocating in OCRAM2, so these variants wouldn't work the same as they did in the 0.2.0 release. `heap_len()` provides just under 512KiB of heap.

If there's no plan to ever update from 0.2.0 to 0.2.1, consider locking the 0.2.0 BSP version.

```
[dependencies.teensy4-bsp]
version = "=0.2.0"
```